### PR TITLE
Allow to override version and heartbeat routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Access `http://localhost:8080/` for a list of the endpoints available and their 
 
 ## Heartbeat and Versioning
 
-To enable `/heartbeat` to echo the git hash of the current build and the timestamp of the current build you will need to use a Makefile to build your executable. You will need to adjust your main.go to support this:
+To enable `/_heartbeat` to echo the git hash of the current build and the timestamp of the current build you will need to use a Makefile to build your executable. You will need to adjust your main.go to support this:
 
 Your `main.go`:
 

--- a/service.go
+++ b/service.go
@@ -17,11 +17,14 @@ import (
 	"github.com/cloudflare/service/render"
 )
 
+// VersionRoute is the path to the version information endpoint
+var VersionRoute string = `/_version`
+
+// HeartbeatRoute is the path to the heartbeat endpoint
+var HeartbeatRoute string = `/_heartbeat`
+
 const (
 	root string = `/`
-
-	// VersionRoute is the path to the version information endpoint
-	VersionRoute string = `/_version`
 )
 
 // EndPoint describes an endpoint that exists on this web service
@@ -55,7 +58,7 @@ func NewWebService() WebService {
 	ws := WebService{}
 
 	// Heartbeat controller (echoes the default version info)
-	heartbeatController := NewWebController("/_heartbeat")
+	heartbeatController := NewWebController(HeartbeatRoute)
 	heartbeatController.AddMethodHandler(Get,
 		func(w http.ResponseWriter, r *http.Request) {
 			v := Version{}


### PR DESCRIPTION
Export `VersionRoute` and `HeartbeatRoute` and make them variable to allow users to override them.
